### PR TITLE
Add Xcode 6.3 final UUID

### DIFF
--- a/DBSmartPanels/Info.plist
+++ b/DBSmartPanels/Info.plist
@@ -27,6 +27,7 @@
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
Added the UUID of the final version of Xcode 6.3, making this plugin compatible with it.